### PR TITLE
Update to pywwt 0.10.0

### DIFF
--- a/binder/setup.sh
+++ b/binder/setup.sh
@@ -14,11 +14,8 @@ pip install PyQt5 "astroquery>=0.3.9" "PyYAML>=3.1.3" --user
 
 # Finally, pywwt. BinderHub only knows to rebuild its images when this file or
 # the Dockerfile changes, so we need a scheme that gives us a nice reason to
-# update this file when we want to target a different version of pywwt. That's
-# why we name a commit ID and not a branch name.
-#
-# Last git reference update: 2020 Aug 20.
-pip install git+https://github.com/WorldWideTelescope/pywwt.git@975a539 --user
+# update this file when we want to target a different version of pywwt.
+pip install https://github.com/WorldWideTelescope/pywwt/archive/pypa/pywwt@0.10.0.zip --user
 
 # Re-build Jupyter Lab
 jupyter lab build


### PR DESCRIPTION
Having trouble getting `pip` to use a commit ID from the `release` branch, but now that our release automation is better ... let's just use Zip files instead.