### PR TITLE
binder/Dockerfile: fix execution on mybinder.org

### DIFF
--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -4,13 +4,19 @@
 
 # https://mybinder.readthedocs.io/en/latest/tutorials/dockerfile.html#preparing-your-dockerfile
 
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
-# Set up Python
+# Set up Python and Node.js.
+#
+# For the time being, Node has to be installed using an extra repo because the
+# version in Ubuntu 20.04 is too old. And we're stuck on 20.04 because the
+# version of Docker used by MyBinder doesn't work with newer Ubuntu releases.
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt update
-RUN apt install -y python3 python3-pip git nodejs npm
+RUN apt install -y curl python3 python3-pip git
+RUN curl -sL https://deb.nodesource.com/setup_16.x |bash
+RUN apt install -y nodejs
 RUN pip3 install --upgrade pip
 
 # Set up user as required by mybinder docs:


### PR DESCRIPTION
The recent image update was failing to build on MyBinder, seemingly due to a bug that happens when older versions of Docker are combined with newer Ubuntu releases:

https://stackoverflow.com/questions/66319610/gpg-error-in-ubuntu-21-04-after-second-apt-get-update-during-docker-build
https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1916485

Dropping to Ubuntu 20.10 doesn't work because it's EOLed (I think -- the `apt update` errors out), so we have to drop to 20.04. That in turn means that we need to install Node.js manually since 20.04's version of it is too old for JupyterLab.